### PR TITLE
add defaults to optional parameters for getVariantContextsFromMAF

### DIFF
--- a/src/main/kotlin/biokotlin/genome/MAFToGVCF.kt
+++ b/src/main/kotlin/biokotlin/genome/MAFToGVCF.kt
@@ -141,8 +141,8 @@ class MAFToGVCF {
         twoGvcfs: Boolean = false,
         outJustGT: Boolean = false,
         outputType: OUTPUT_TYPE = OUTPUT_TYPE.gvcf,
-        delAsSymbolic: Boolean,
-        maxDeletionSize: Int
+        delAsSymbolic: Boolean = false,
+        maxDeletionSize: Int = 0
     ): Map<String, List<VariantContext>> {
 
         val mafRecords = loadMAFRecords(mafFile)


### PR DESCRIPTION
Minor fix to add defaults to getVariantContextsFromMAF so that new parameters don't need to be specified.