### PR TITLE
change convertStates default to true, add param to NucSeq()

### DIFF
--- a/src/main/kotlin/biokotlin/seq/NucSeq2Bit.kt
+++ b/src/main/kotlin/biokotlin/seq/NucSeq2Bit.kt
@@ -24,11 +24,11 @@ import java.util.stream.Collectors
  * Factoring for method for creating [NucSeq2Bit].
  * @param seq sequence in a String
  * @param preferredNucSet the preferred sequence either [NUC.DNA] or [NUC.RNA]
- * @param checkStates is true the states will be checked, and unless convert states it will reject all non - (A,C,G,T,U,N)
- * @param convertStates is true it will convert all non - (A,C,G,T,U,N) to N
+ * @param checkStates if true the states will be checked, and unless convert states it will reject all non - (A,C,G,T,U,N)
+ * @param convertStates if true it will convert all non - (A,C,G,T,U,N) to N
  */
 internal fun NucSeq2Bit(seq: String, preferredNucSet: NucSet = NUC.DNA, checkStates: Boolean = true,
-                        convertStates: Boolean = false): NucSeq2Bit {
+                        convertStates: Boolean = true): NucSeq2Bit {
     val seqs2B = NucSeq2Bit.seqStringTo2Bit(seq, checkStates, convertStates)
     return when (preferredNucSet) {
         NUC.DNA, NUC.AmbiguousDNA -> DNASeq2Bit(seqs2B)

--- a/src/main/kotlin/biokotlin/seq/Seq.kt
+++ b/src/main/kotlin/biokotlin/seq/Seq.kt
@@ -62,17 +62,17 @@ fun Seq(seq: String): NucSeq {
  * ```
  *
  */
-fun NucSeq(vararg seq: String): NucSeq {
+fun NucSeq(vararg seq: String, convertStates: Boolean = true): NucSeq {
     val seqS = seq.joinToString(separator = "")
-    return if(seqS.length < 1_000_000) NucSeqByteEncode(seqS) else NucSeq2Bit(seqS)
+    return if(seqS.length < 1_000_000) NucSeqByteEncode(seqS) else NucSeq2Bit(seqS,convertStates=convertStates)
 }
 
 /**Create a NucSeq with a specified NucSet
  *
  * @param preferredNucSet can be [NUC.DNA],[NUC.RNA],[NUC.AmbiguousDNA] or [NUC.AmbiguousRNA]
  * */
-fun NucSeq(seq: String, preferredNucSet: NucSet): NucSeq {
-    return if(seq.length < 1_000_000) NucSeqByteEncode(seq, preferredNucSet) else NucSeq2Bit(seq, preferredNucSet)
+fun NucSeq(seq: String, preferredNucSet: NucSet,convertStates: Boolean = true): NucSeq {
+    return if(seq.length < 1_000_000) NucSeqByteEncode(seq, preferredNucSet) else NucSeq2Bit(seq, preferredNucSet,convertStates=convertStates)
 }
 
 //fun NucSeq(seq: List<NUC>): NucSeq = TODO()

--- a/src/test/kotlin/biokotlin/seq/NucSeq2BitTest.kt
+++ b/src/test/kotlin/biokotlin/seq/NucSeq2BitTest.kt
@@ -75,9 +75,9 @@ class NucSeq2BitTest : StringSpec({
     }
 */
     "Test conversion of X to N in DNA" {
-        shouldThrow<java.lang.IllegalStateException> { NucSeq2Bit("GCXT") }
-        NucSeq2Bit("GCXT", convertStates = true).seq() shouldBe "GCNT"
-        NucSeq2Bit("GCxT", convertStates = true).seq() shouldBe "GCNT"
+        shouldThrow<java.lang.IllegalStateException> { NucSeq2Bit("GCXT", convertStates=false) }
+        NucSeq2Bit("GCXT").seq() shouldBe "GCNT"
+        NucSeq2Bit("GCxT").seq() shouldBe "GCNT"
         NucSeq2Bit("GCNT").seq() shouldBe "GCNT"
     }
 


### PR DESCRIPTION
Changing convertStates default to "true" in NucSeq2Bit, add "convertStates" parameter to NucSeq.  Fixes problem when loading genomes with NucSeq() that have lower case letters.