### PR TITLE
Maf to gvcf update

### DIFF
--- a/src/main/kotlin/biokotlin/cli/MafToGvcfConverter.kt
+++ b/src/main/kotlin/biokotlin/cli/MafToGvcfConverter.kt
@@ -82,7 +82,7 @@ class MafToGvcfConverter : CliktCommand(help = "Create a GVCF file from a MAF fi
         .int()
         .default(0)
 
-    val anchorwaveLegacy by option(help = "Defaults to false.  Enable this option if the MAF was created prior to Anchorwave version 1.2.3.  Otherwise the ")
+    val anchorwaveLegacy by option(help = "Defaults to false.  Enable this option if the MAF was created prior to Anchorwave version 1.2.3.  Otherwise the ASM coordinates will not be correct. ")
         .flag(default = false)
 
     override fun run() {

--- a/src/main/kotlin/biokotlin/cli/MafToGvcfConverter.kt
+++ b/src/main/kotlin/biokotlin/cli/MafToGvcfConverter.kt
@@ -82,6 +82,9 @@ class MafToGvcfConverter : CliktCommand(help = "Create a GVCF file from a MAF fi
         .int()
         .default(0)
 
+    val anchorwaveLegacy by option(help = "Defaults to false.  Enable this option if the MAF was created prior to Anchorwave version 1.2.3.  Otherwise the ")
+        .flag(default = false)
+
     override fun run() {
         println("LCJ begin run: fillGaps = $fillGaps, twoGvcfs = $twoGvcfs, outJustGT = $outJustGT, compressAndIndex = $compressAndIndex, delAsSymbolic = $delAsSymbolic,  outputType = $outputType")
         val outputType = try {
@@ -104,7 +107,8 @@ class MafToGvcfConverter : CliktCommand(help = "Create a GVCF file from a MAF fi
             outputType,
             compressAndIndex,
             delAsSymbolic,
-            maxDeletionSize
+            maxDeletionSize,
+            anchorwaveLegacy
         )
 
     }

--- a/src/test/kotlin/biokotlin/genome/MAFToGVCFTest.kt
+++ b/src/test/kotlin/biokotlin/genome/MAFToGVCFTest.kt
@@ -710,7 +710,6 @@ class MAFToGVCFTest : StringSpec({
             //Check ASM Contig
             (matchingTruth.getAttribute("ASM_Chr") == variant.getAttribute("ASM_Chr")) shouldBe true
             //Check ASM Start
-            println("ASM_Start: ${matchingTruth.getAttribute("ASM_Start")} == ${variant.getAttribute("ASM_Start")}")
             (matchingTruth.getAttribute("ASM_Start") == variant.getAttribute("ASM_Start")) shouldBe true
             //Check ASM END
             (matchingTruth.getAttribute("ASM_End") == variant.getAttribute("ASM_End")) shouldBe true


### PR DESCRIPTION
Updating how the ASM coordinates are handled when converting the MAF file to the GVCF.  This change is prompted due to a correction in how anchorwave creates these coordinates and now does it correctly.  For backwards compatibility sake there is now an anchorwave-legacy parameter so people can convert files made prior to the change correctly still.  Once this is in and built I will also update the phgv2 code to match.